### PR TITLE
Fix: fix Failed to pull image "ghcr.io/jumpserver/core-ce:v3.10.10": Error response from daemon: manifest unknown --

### DIFF
--- a/charts/jumpserver/templates/pre-install-initdb.yaml
+++ b/charts/jumpserver/templates/pre-install-initdb.yaml
@@ -1,7 +1,7 @@
 {{- with .Values.core }}
 {{- $fullName := include "jumpserver.fullname" $ }}
 {{- $containerName := "jms-init-db" }}
-{{- $registryName := default .image.registry | $.Values.global.imageRegistry }}
+{{- $registryName := .image.registry | default $.Values.global.imageRegistry }}
 {{- $imageOwner :=  $.Values.global.imageOwner | default "jumpserver" }}
 {{- $imageName := $.Values.xpack.enabled | ternary "core-ee" "core-ce" }}
 {{- $imageTag := $.Chart.AppVersion }}

--- a/charts/jumpserver/templates/pre-install-initdb.yaml
+++ b/charts/jumpserver/templates/pre-install-initdb.yaml
@@ -1,7 +1,7 @@
 {{- with .Values.core }}
 {{- $fullName := include "jumpserver.fullname" $ }}
 {{- $containerName := "jms-init-db" }}
-{{- $registryName := $.Values.global.imageRegistry | default .image.registry }}
+{{- $registryName := default .image.registry | $.Values.global.imageRegistry }}
 {{- $imageOwner :=  $.Values.global.imageOwner | default "jumpserver" }}
 {{- $imageName := $.Values.xpack.enabled | ternary "core-ee" "core-ce" }}
 {{- $imageTag := $.Chart.AppVersion }}

--- a/charts/jumpserver/values.yaml
+++ b/charts/jumpserver/values.yaml
@@ -11,7 +11,7 @@ fullnameOverride: ""
 ## @param global.redis.password Global Redis&trade; password (overrides `auth.password`)
 ##
 global:
-  imageRegistry: ghcr.io
+  imageRegistry: docker.io
   imageOwner: jumpserver
   ## E.g.
   #  imagePullSecrets:


### PR DESCRIPTION
Hi, I am reaching out regarding the necessary adjustments for the following issue on GitHub: https://github.com/jumpserver/helm-charts/issues/152.

It appears that the current logic is incorrect. Presently, the process involves using $.Values.global.imageRegistry first. If $.Values.global.imageRegistry does not exist, the code falls back to .image.registry. However, the correct approach should prioritize using .image.registry first. Furthermore, the image reference should be updated accordingly.

To illustrate, here is a sample core configuration that has proven effective for me:

```yaml
core:
  affinity: {}
  config:
    bootstrapToken: 'X2lRdRRZXn8LXgj5Gg3iQKwEpK2Fwg3x0VQE1tcPI55jSCZ1yw'
    debug: false
    log:
      level: ERROR
    secretKey: 'VupPkILPnHC5xzfD74Ghw1tzivt3iH7UOeJcWFMtgEaMupoHPc'
  enabled: true
  env:
    SESSION_EXPIRE_AT_BROWSER_CLOSE: true
  image:
    pullPolicy: IfNotPresent
    registry: docker.io
  labels:
    app.jumpserver.org/name: jms-core
  livenessProbe:
    exec:
      command:
        - curl
        - '-fsL'
        - http://localhost:8080/api/health/
    failureThreshold: 3
    initialDelaySeconds: 90
    timeoutSeconds: 5
  nodeSelector: {}
  persistence:
    accessModes:
      - ReadWriteMany
    annotations:
      helm.sh/resource-policy: keep
    finalizers:
      - kubernetes.io/pvc-protection
    size: 100Gi
    storageClassName: jumpserver-data
  podSecurityContext: {}
  replicaCount: 1
  resources: {}
  securityContext: {}
  service:
    type: ClusterIP
    web:
      port: 8080
  tolerations: []
  volumeMounts: []
  volumes: []
```

Additionally, there are similar instances of this issue within the helm that also require attention and correction. 